### PR TITLE
Add Automated Candle Data Fetching and Updating Workflow

### DIFF
--- a/.github/workflows/update_candles.yaml
+++ b/.github/workflows/update_candles.yaml
@@ -1,0 +1,30 @@
+name: Update Candles
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'  # Runs every 15 minutes
+  workflow_dispatch:  # Allows manual triggering of the workflow
+
+jobs:
+  update-candles:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install ccxt PyGithub pandas
+
+    - name: Fetch and update candles
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Use GitHub token for authentication
+      run: |
+        python fetch_candles.py

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,8 @@ setup(
     license='MIT',
     packages=find_packages(),
     install_requires=[
-        'PyGithub>=1.55',
+        'ccxt>=4.3.87,<5',
+        'PyGithub>=1.55,<2',
     ],
     classifiers=[
         'Programming Language :: Python :: 3',

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,9 @@ setup(
     license='MIT',
     packages=find_packages(),
     install_requires=[
-        'ccxt>=4.3.87,<5',
-        'PyGithub>=1.55,<2',
+        'PyGithub>=1.55,<2.0',
+        'ccxt>=4.3.87,<5.0',
+        'pandas>=2.2.2,<3.0',
     ],
     classifiers=[
         'Programming Language :: Python :: 3',

--- a/tests/test_fetch_candles.py
+++ b/tests/test_fetch_candles.py
@@ -4,26 +4,30 @@ from tickr.fetch_candles import fetch_and_save_candles
 
 class TestFetchCandles(unittest.TestCase):
 
+    @patch('tickr.fetch_candles.get_github_repo')
+    @patch('tickr.fetch_candles.save_and_update_github')
     @patch('tickr.fetch_candles.exchange')
-    @patch('tickr.fetch_candles.repo')
-    def test_fetch_and_save_candles(self, mock_repo, mock_exchange):
+    def test_fetch_and_save_candles(self, mock_exchange, mock_save_and_update, mock_get_repo):
         # Setup mock return values
         mock_exchange.fetch_ohlcv.return_value = [
             [1609459200000, 29000, 29500, 28800, 29400, 1000],  # Mocked candle data
             [1609545600000, 29400, 29700, 29200, 29500, 1200]
         ]
         
-        mock_repo.get_contents.return_value = MagicMock()
-        mock_repo.update_file.return_value = MagicMock()
-        mock_repo.create_file.return_value = MagicMock()
+        mock_repo = MagicMock()
+        mock_get_repo.return_value = mock_repo
 
         # Run the function
         fetch_and_save_candles('BTC/USDT')
 
         # Assertions
         mock_exchange.fetch_ohlcv.assert_called_once_with('BTC/USDT', '1m', since=mock_exchange.parse8601('2021-01-01T00:00:00Z'))
-        mock_repo.get_contents.assert_called()
-        mock_repo.update_file.assert_called()
+        mock_save_and_update.assert_called()
+
+        # Check that the correct sharded file paths were used in the save_and_update_github call
+        expected_file_path = 'data/BTC-USDT/1m/2021/01/BTC-USDT_1m_2021-01.json'
+        args, kwargs = mock_save_and_update.call_args
+        self.assertIn(expected_file_path, args)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_fetch_candles.py
+++ b/tests/test_fetch_candles.py
@@ -1,0 +1,25 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from tickr.fetch_candles import fetch_and_save_candles
+
+class TestFetchCandles(unittest.TestCase):
+
+    @patch('tickr.fetch_candles.exchange')
+    @patch('tickr.fetch_candles.update_github_file')
+    def test_fetch_and_save_candles(self, mock_update_github, mock_exchange):
+        # Setup mock return values
+        mock_exchange.fetch_ohlcv.return_value = [
+            [1609459200000, 29000, 29500, 28800, 29400, 1000],  # Mocked candle data
+            [1609545600000, 29400, 29700, 29200, 29500, 1200]
+        ]
+        mock_update_github.return_value = None
+
+        # Run the function
+        fetch_and_save_candles('BTC/USDT')
+
+        # Assertions
+        mock_exchange.fetch_ohlcv.assert_called_once_with('BTC/USDT', '1m', since=mock_exchange.parse8601('2021-01-01T00:00:00Z'))
+        mock_update_github.assert_called()  # Check if the GitHub update function was called
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_fetch_candles.py
+++ b/tests/test_fetch_candles.py
@@ -22,12 +22,13 @@ class TestFetchCandles(unittest.TestCase):
 
         # Assertions
         mock_exchange.fetch_ohlcv.assert_called_once_with('BTC/USDT', '1m', since=mock_exchange.parse8601('2021-01-01T00:00:00Z'))
-        mock_save_and_update.assert_called()
-
-        # Check that the correct sharded file paths were used in the save_and_update_github call
-        expected_file_path = 'data/BTC-USDT/1min/2021/01/BTC-USDT_1min_2021-01.json'
-        called_file_path = mock_save_and_update.call_args[0][0]  # First positional argument is the file path
-        self.assertEqual(expected_file_path, called_file_path)
+        
+        # Check that save_and_update_github was called for each timeframe
+        timeframes = ['1min', '5min', '15min', '1H', '6H', '12H', '1D', '1W']
+        for timeframe in timeframes:
+            expected_file_path = f'data/BTC-USDT/{timeframe}/2021/01/BTC-USDT_{timeframe}_2021-01.json'
+            called_file_path = mock_save_and_update.call_args_list[timeframes.index(timeframe)][0][0]
+            self.assertEqual(expected_file_path, called_file_path)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_fetch_candles.py
+++ b/tests/test_fetch_candles.py
@@ -5,21 +5,25 @@ from tickr.fetch_candles import fetch_and_save_candles
 class TestFetchCandles(unittest.TestCase):
 
     @patch('tickr.fetch_candles.exchange')
-    @patch('tickr.fetch_candles.update_github_file')
-    def test_fetch_and_save_candles(self, mock_update_github, mock_exchange):
+    @patch('tickr.fetch_candles.repo')
+    def test_fetch_and_save_candles(self, mock_repo, mock_exchange):
         # Setup mock return values
         mock_exchange.fetch_ohlcv.return_value = [
             [1609459200000, 29000, 29500, 28800, 29400, 1000],  # Mocked candle data
             [1609545600000, 29400, 29700, 29200, 29500, 1200]
         ]
-        mock_update_github.return_value = None
+        
+        mock_repo.get_contents.return_value = MagicMock()
+        mock_repo.update_file.return_value = MagicMock()
+        mock_repo.create_file.return_value = MagicMock()
 
         # Run the function
         fetch_and_save_candles('BTC/USDT')
 
         # Assertions
         mock_exchange.fetch_ohlcv.assert_called_once_with('BTC/USDT', '1m', since=mock_exchange.parse8601('2021-01-01T00:00:00Z'))
-        mock_update_github.assert_called()  # Check if the GitHub update function was called
+        mock_repo.get_contents.assert_called()
+        mock_repo.update_file.assert_called()
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_fetch_candles.py
+++ b/tests/test_fetch_candles.py
@@ -24,7 +24,7 @@ class TestFetchCandles(unittest.TestCase):
         mock_exchange.fetch_ohlcv.assert_called_once_with('BTC/USDT', '1m', since=mock_exchange.parse8601('2021-01-01T00:00:00Z'))
         
         # Check that save_and_update_github was called for each timeframe
-        timeframes = ['1min', '5min', '15min', '1H', '6H', '12H', '1D', '1W']
+        timeframes = ['1m', '5m', '15m', '1H', '6H', '12H', '1D', '1W']
         for timeframe in timeframes:
             expected_file_path = f'data/BTC-USDT/{timeframe}/2021/01/BTC-USDT_{timeframe}_2021-01.json'
             called_file_path = mock_save_and_update.call_args_list[timeframes.index(timeframe)][0][0]

--- a/tests/test_fetch_candles.py
+++ b/tests/test_fetch_candles.py
@@ -24,7 +24,7 @@ class TestFetchCandles(unittest.TestCase):
         mock_exchange.fetch_ohlcv.assert_called_once_with('BTC/USDT', '1m', since=mock_exchange.parse8601('2021-01-01T00:00:00Z'))
         
         # Check that save_and_update_github was called for each timeframe
-        timeframes = ['1m', '5m', '15m', '1H', '6H', '12H', '1D', '1W']
+        timeframes = ['1m', '5m', '15m', '1h', '6h', '12h', '1d', '1w']
         for timeframe in timeframes:
             expected_file_path = f'data/BTC-USDT/{timeframe}/2021/01/BTC-USDT_{timeframe}_2021-01.json'
             called_file_path = mock_save_and_update.call_args_list[timeframes.index(timeframe)][0][0]

--- a/tests/test_fetch_candles.py
+++ b/tests/test_fetch_candles.py
@@ -25,9 +25,9 @@ class TestFetchCandles(unittest.TestCase):
         mock_save_and_update.assert_called()
 
         # Check that the correct sharded file paths were used in the save_and_update_github call
-        expected_file_path = 'data/BTC-USDT/1m/2021/01/BTC-USDT_1m_2021-01.json'
-        args, kwargs = mock_save_and_update.call_args
-        self.assertIn(expected_file_path, args)
+        expected_file_path = 'data/BTC-USDT/1min/2021/01/BTC-USDT_1min_2021-01.json'
+        called_file_path = mock_save_and_update.call_args[0][0]  # First positional argument is the file path
+        self.assertEqual(expected_file_path, called_file_path)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tickr/fetch_candles.py
+++ b/tickr/fetch_candles.py
@@ -1,8 +1,8 @@
 """
 fetch_candles.py
 
-This script fetches the latest 1-minute cryptocurrency candle data using the CCXT library and resamples it
-to generate candles for larger timeframes. It then updates the local data files in the repository.
+This script fetches the latest cryptocurrency candle data using the CCXT library and updates
+the local data files in the repository. It is intended to be run manually or via a scheduled GitHub Actions workflow.
 
 License: MIT
 """
@@ -23,10 +23,15 @@ DATA_DIR = 'data'
 # Initialize exchange
 exchange = getattr(ccxt, EXCHANGE_ID)()
 
-# Load your GitHub token
-GITHUB_TOKEN = os.getenv('GITHUB_TOKEN')
-g = Github(GITHUB_TOKEN)
-repo = g.get_repo('your_username/tickr')  # Replace 'your_username/tickr' with your actual repo path
+def get_github_repo():
+    """
+    Initializes and returns the GitHub repository object.
+    This function allows delaying the GitHub initialization for easier testing and mocking.
+    """
+    GITHUB_TOKEN = os.getenv('GITHUB_TOKEN')
+    g = Github(GITHUB_TOKEN)
+    repo = g.get_repo('your_username/tickr')  # Replace 'your_username/tickr' with your actual repo path
+    return repo
 
 def fetch_and_save_candles(symbol):
     """
@@ -84,9 +89,10 @@ def save_and_update_github(file_path, resampled, symbol, timeframe):
         json.dump(combined_candles, f)
     
     # Update the file in the GitHub repository
-    update_github_file(file_path, symbol, timeframe)
+    repo = get_github_repo()
+    update_github_file(repo, file_path, symbol, timeframe)
 
-def update_github_file(file_path, symbol, timeframe):
+def update_github_file(repo, file_path, symbol, timeframe):
     """
     Updates the file in the GitHub repository with the latest candle data.
     """

--- a/tickr/fetch_candles.py
+++ b/tickr/fetch_candles.py
@@ -1,0 +1,114 @@
+"""
+fetch_candles.py
+
+This script fetches the latest 1-minute cryptocurrency candle data using the CCXT library and resamples it
+to generate candles for larger timeframes. It then updates the local data files in the repository.
+
+License: MIT
+"""
+
+import ccxt
+import json
+import os
+from datetime import datetime
+from github import Github
+import pandas as pd
+
+# Configuration
+EXCHANGE_ID = 'binance'
+SYMBOLS = ['BTC/USDT']  # Add more symbols if needed
+TIMEFRAMES = ['5m', '15m', '1h', '6h', '12h', '1d', '1w']
+DATA_DIR = 'data'
+
+# Initialize exchange
+exchange = getattr(ccxt, EXCHANGE_ID)()
+
+# Load your GitHub token
+GITHUB_TOKEN = os.getenv('GITHUB_TOKEN')
+g = Github(GITHUB_TOKEN)
+repo = g.get_repo('your_username/tickr')  # Replace 'your_username/tickr' with your actual repo path
+
+def fetch_and_save_candles(symbol):
+    """
+    Fetches 1m candles from the exchange and resamples them to various timeframes.
+    """
+    print(f"Fetching 1m candles for {symbol}...")
+    
+    # Fetch 1-minute candles from the exchange
+    since = exchange.parse8601('2021-01-01T00:00:00Z')  # Start date for fetching candles (adjust as needed)
+    candles = exchange.fetch_ohlcv(symbol, '1m', since=since)
+
+    # Convert to DataFrame for resampling
+    df = pd.DataFrame(candles, columns=['timestamp', 'open', 'high', 'low', 'close', 'volume'])
+    df['timestamp'] = pd.to_datetime(df['timestamp'], unit='ms')
+    df.set_index('timestamp', inplace=True)
+
+    # Save and resample for each timeframe
+    for timeframe in TIMEFRAMES:
+        resampled = df.resample(timeframe).agg({
+            'open': 'first',
+            'high': 'max',
+            'low': 'min',
+            'close': 'last',
+            'volume': 'sum'
+        }).dropna()
+        
+        # Save and update data
+        file_path = os.path.join(DATA_DIR, f"{symbol.replace('/', '-')}_{timeframe}.json")
+        save_and_update_github(file_path, resampled, symbol, timeframe)
+
+def save_and_update_github(file_path, resampled, symbol, timeframe):
+    """
+    Saves resampled candles to a file and updates the GitHub repository.
+    """
+    # Load existing data if file exists
+    existing_candles = []
+    if os.path.exists(file_path):
+        with open(file_path, 'r') as f:
+            existing_candles = json.load(f)
+    
+    # Combine existing and new candles, ensuring no duplicates
+    existing_df = pd.DataFrame(existing_candles, columns=['timestamp', 'open', 'high', 'low', 'close', 'volume'])
+    if not existing_df.empty:
+        existing_df['timestamp'] = pd.to_datetime(existing_df['timestamp'], unit='ms')
+        existing_df.set_index('timestamp', inplace=True)
+        combined_df = pd.concat([existing_df, resampled])
+        combined_df = combined_df[~combined_df.index.duplicated(keep='last')]
+    else:
+        combined_df = resampled
+
+    # Save updated data back to the file
+    combined_df.reset_index(inplace=True)
+    combined_candles = combined_df.to_dict('records')
+    with open(file_path, 'w') as f:
+        json.dump(combined_candles, f)
+    
+    # Update the file in the GitHub repository
+    update_github_file(file_path, symbol, timeframe)
+
+def update_github_file(file_path, symbol, timeframe):
+    """
+    Updates the file in the GitHub repository with the latest candle data.
+    """
+    with open(file_path, 'r') as f:
+        content = f.read()
+
+    repo_file_path = f"data/{symbol.replace('/', '-')}_{timeframe}.json"
+    try:
+        # Update existing file
+        contents = repo.get_contents(repo_file_path)
+        repo.update_file(contents.path, f"Update {symbol} {timeframe} candles", content, contents.sha)
+    except Exception as e:
+        # Create new file if it doesn't exist
+        repo.create_file(repo_file_path, f"Add {symbol} {timeframe} candles", content)
+        print(f"Created new file for {symbol} {timeframe} candles in GitHub repo.")
+
+def main():
+    if not os.path.exists(DATA_DIR):
+        os.makedirs(DATA_DIR)
+
+    for symbol in SYMBOLS:
+        fetch_and_save_candles(symbol)
+
+if __name__ == "__main__":
+    main()

--- a/tickr/fetch_candles.py
+++ b/tickr/fetch_candles.py
@@ -15,40 +15,31 @@ from github import Github
 import pandas as pd
 
 # Configuration
-EXCHANGE_ID = 'binance'
-SYMBOLS = ['BTC/USDT']  # Add more symbols if needed
-TIMEFRAMES = ['5m', '15m', '1h', '6h', '12h', '1d', '1w']
+EXCHANGE_ID = 'binance' # TODO: parameterize this
+SYMBOLS = ['BTC/USDT']  # TODO: Add more symbols or paramaterize if needed
+TIMEFRAMES = ['1m', '5m', '15m', '1h', '6h', '12h', '1d', '1w']
 DATA_DIR = 'data'
 
 # Initialize exchange
 exchange = getattr(ccxt, EXCHANGE_ID)()
 
 def get_github_repo():
-    """
-    Initializes and returns the GitHub repository object.
-    This function allows delaying the GitHub initialization for easier testing and mocking.
-    """
     GITHUB_TOKEN = os.getenv('GITHUB_TOKEN')
     g = Github(GITHUB_TOKEN)
-    repo = g.get_repo('your_username/tickr')  # Replace 'your_username/tickr' with your actual repo path
+    repo = g.get_repo('syncsoftco/tickr') # TODO: parameterize this
     return repo
 
 def fetch_and_save_candles(symbol):
-    """
-    Fetches 1m candles from the exchange and resamples them to various timeframes.
-    """
     print(f"Fetching 1m candles for {symbol}...")
     
     # Fetch 1-minute candles from the exchange
-    since = exchange.parse8601('2021-01-01T00:00:00Z')  # Start date for fetching candles (adjust as needed)
+    since = exchange.parse8601('2021-01-01T00:00:00Z')
     candles = exchange.fetch_ohlcv(symbol, '1m', since=since)
 
-    # Convert to DataFrame for resampling
     df = pd.DataFrame(candles, columns=['timestamp', 'open', 'high', 'low', 'close', 'volume'])
     df['timestamp'] = pd.to_datetime(df['timestamp'], unit='ms')
     df.set_index('timestamp', inplace=True)
 
-    # Save and resample for each timeframe
     for timeframe in TIMEFRAMES:
         resampled = df.resample(timeframe).agg({
             'open': 'first',
@@ -58,23 +49,22 @@ def fetch_and_save_candles(symbol):
             'volume': 'sum'
         }).dropna()
         
-        # Save and update data
-        file_path = os.path.join(DATA_DIR, f"{symbol.replace('/', '-')}_{timeframe}.json")
-        save_and_update_github(file_path, resampled, symbol, timeframe)
+        for name, group in resampled.groupby([resampled.index.year, resampled.index.month]):
+            year, month = name
+            shard_filename = f"{symbol.replace('/', '-')}_{timeframe}_{year}-{month:02d}.json"
+            file_path = os.path.join(DATA_DIR, symbol.replace('/', '-'), timeframe, str(year), f"{month:02d}", shard_filename)
 
-def save_and_update_github(file_path, resampled, symbol, timeframe):
-    """
-    Saves resampled candles to a file and updates the GitHub repository.
-    """
+            if not os.path.exists(os.path.dirname(file_path)):
+                os.makedirs(os.path.dirname(file_path))
+            
+            save_and_update_github(file_path, group, symbol, timeframe, year, month)
+
+def save_and_update_github(file_path, resampled, symbol, timeframe, year, month):
     # Load existing data if file exists
-    existing_candles = []
     if os.path.exists(file_path):
         with open(file_path, 'r') as f:
             existing_candles = json.load(f)
-    
-    # Combine existing and new candles, ensuring no duplicates
-    existing_df = pd.DataFrame(existing_candles, columns=['timestamp', 'open', 'high', 'low', 'close', 'volume'])
-    if not existing_df.empty:
+        existing_df = pd.DataFrame(existing_candles, columns=['timestamp', 'open', 'high', 'low', 'close', 'volume'])
         existing_df['timestamp'] = pd.to_datetime(existing_df['timestamp'], unit='ms')
         existing_df.set_index('timestamp', inplace=True)
         combined_df = pd.concat([existing_df, resampled])
@@ -82,32 +72,25 @@ def save_and_update_github(file_path, resampled, symbol, timeframe):
     else:
         combined_df = resampled
 
-    # Save updated data back to the file
     combined_df.reset_index(inplace=True)
     combined_candles = combined_df.to_dict('records')
     with open(file_path, 'w') as f:
         json.dump(combined_candles, f)
-    
-    # Update the file in the GitHub repository
-    repo = get_github_repo()
-    update_github_file(repo, file_path, symbol, timeframe)
 
-def update_github_file(repo, file_path, symbol, timeframe):
-    """
-    Updates the file in the GitHub repository with the latest candle data.
-    """
+    repo = get_github_repo()
+    update_github_file(repo, file_path, symbol, timeframe, year, month)
+
+def update_github_file(repo, file_path, symbol, timeframe, year, month):
     with open(file_path, 'r') as f:
         content = f.read()
 
-    repo_file_path = f"data/{symbol.replace('/', '-')}_{timeframe}.json"
+    repo_file_path = os.path.relpath(file_path, DATA_DIR).replace('\\', '/')
     try:
-        # Update existing file
         contents = repo.get_contents(repo_file_path)
-        repo.update_file(contents.path, f"Update {symbol} {timeframe} candles", content, contents.sha)
-    except Exception as e:
-        # Create new file if it doesn't exist
-        repo.create_file(repo_file_path, f"Add {symbol} {timeframe} candles", content)
-        print(f"Created new file for {symbol} {timeframe} candles in GitHub repo.")
+        repo.update_file(contents.path, f"Update {symbol} {timeframe} candles for {year}-{month:02d}", content, contents.sha)
+    except Exception:
+        repo.create_file(repo_file_path, f"Add {symbol} {timeframe} candles for {year}-{month:02d}", content)
+        print(f"Created new shard file {repo_file_path} in GitHub repo.")
 
 def main():
     if not os.path.exists(DATA_DIR):


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow that automates the fetching, resampling, and updating of cryptocurrency candle data using the CCXT library. Key features include:

- **GitHub Actions Workflow (`update_candles.yaml`)**: 
  - The workflow is scheduled to run every 15 minutes and can also be triggered manually.
  - It checks out the code, sets up the Python environment, installs dependencies (`ccxt`, `PyGithub`, and `pandas`), and runs the `fetch_candles.py` script to fetch and update the candle data.

- **Candle Fetching Script (`fetch_candles.py`)**: 
  - Fetches 1-minute candles from the Binance exchange for specified symbols (currently `BTC/USDT`).
  - Resamples the data into various timeframes (`5m`, `15m`, `1h`, `6h`, `12h`, `1d`, `1w`) and saves it locally.
  - Updates the corresponding JSON files in the GitHub repository, creating new files if they don't already exist.

- **Unit Tests (`test_fetch_candles.py`)**: 
  - Includes unit tests for the `fetch_and_save_candles` function using mocks to simulate exchange and GitHub interactions.

- **Dependencies**:
  - Added required dependencies to `setup.py`: `ccxt`, `PyGithub`, and `pandas`.

This PR automates the process of keeping candle data up to date in the GitHub repository, ensuring that the latest data is always available for further analysis or use.