### PR TITLE
Convert Timestamps to Milliseconds Since Epoch and Save Updated Data

### DIFF
--- a/tickr/fetch_candles.py
+++ b/tickr/fetch_candles.py
@@ -72,8 +72,12 @@ def save_and_update_github(file_path, resampled, symbol, timeframe, year, month)
     else:
         combined_df = resampled
 
+    # Convert the DataFrame index (Timestamp) to milliseconds since epoch
     combined_df.reset_index(inplace=True)
+    combined_df['timestamp'] = combined_df['timestamp'].apply(lambda x: int(x.timestamp() * 1000))
     combined_candles = combined_df.to_dict('records')
+
+    # Save updated data back to the file
     with open(file_path, 'w') as f:
         json.dump(combined_candles, f)
 


### PR DESCRIPTION
This PR introduces the following changes to the `tickr/fetch_candles.py` script:

1. **Timestamp Conversion**:
   - The DataFrame index (`timestamp`) is converted to milliseconds since the epoch. This change ensures that the timestamp format is consistent and suitable for various applications that may require epoch time in milliseconds.
   - The conversion is achieved by applying a lambda function that multiplies the `timestamp` by 1000 to convert it from seconds to milliseconds.

2. **Saving Updated Data**:
   - The updated data is saved back to the file after converting the timestamps. This ensures that the data in the file is up-to-date with the new timestamp format.

These changes are crucial for ensuring compatibility with systems that expect timestamps in milliseconds since epoch. Additionally, saving the updated data back to the file ensures that the data is persistent and can be used for further processing or analysis.