### PR TITLE
Improve Candle Resampling and GitHub File Path Handling

### DIFF
--- a/tests/test_fetch_candles.py
+++ b/tests/test_fetch_candles.py
@@ -23,14 +23,11 @@ class TestFetchCandles(unittest.TestCase):
         # Assertions
         mock_exchange.fetch_ohlcv.assert_called_once_with('BTC/USDT', '1m', since=mock_exchange.parse8601('2021-01-01T00:00:00Z'))
         
-        # Ensure save_and_update_github was called for all timeframes
-        timeframes = ['1m', '5m', '15m', '1h', '6h', '12h', '1d', '1w']
-        self.assertEqual(len(mock_save_and_update.call_args_list), len(timeframes))
-
-        # Check that save_and_update_github was called with the correct file path for each timeframe
-        for i, timeframe in enumerate(timeframes):
-            expected_file_path = f'data/BTC-USDT/{timeframe}/2021/01/kraken_BTC-USDT_{timeframe}_2021-01.json'
-            called_file_path = mock_save_and_update.call_args_list[i][0][0]
+        # Check that save_and_update_github was called for each timeframe
+        timeframes = ['1T', '5T', '15T', '1H', '6H', '12H', '1D', '1W']
+        for timeframe in timeframes:
+            expected_file_path = os.path.join('data', 'kraken', 'BTC-USDT', timeframe, '2021', '01', f'kraken_BTC-USDT_{timeframe}_2021-01.json')
+            called_file_path = mock_save_and_update.call_args_list[timeframes.index(timeframe)][0][0]
             self.assertEqual(expected_file_path, called_file_path)
 
 if __name__ == '__main__':

--- a/tests/test_fetch_candles.py
+++ b/tests/test_fetch_candles.py
@@ -23,11 +23,14 @@ class TestFetchCandles(unittest.TestCase):
         # Assertions
         mock_exchange.fetch_ohlcv.assert_called_once_with('BTC/USDT', '1m', since=mock_exchange.parse8601('2021-01-01T00:00:00Z'))
         
-        # Check that save_and_update_github was called for each timeframe
+        # Ensure save_and_update_github was called for all timeframes
         timeframes = ['1m', '5m', '15m', '1h', '6h', '12h', '1d', '1w']
-        for timeframe in timeframes:
+        self.assertEqual(len(mock_save_and_update.call_args_list), len(timeframes))
+
+        # Check that save_and_update_github was called with the correct file path for each timeframe
+        for i, timeframe in enumerate(timeframes):
             expected_file_path = f'data/BTC-USDT/{timeframe}/2021/01/kraken_BTC-USDT_{timeframe}_2021-01.json'
-            called_file_path = mock_save_and_update.call_args_list[timeframes.index(timeframe)][0][0]
+            called_file_path = mock_save_and_update.call_args_list[i][0][0]
             self.assertEqual(expected_file_path, called_file_path)
 
 if __name__ == '__main__':

--- a/tests/test_fetch_candles.py
+++ b/tests/test_fetch_candles.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 from unittest.mock import patch, MagicMock
 from tickr.fetch_candles import fetch_and_save_candles


### PR DESCRIPTION
This pull request includes the following improvements and changes:

1. **Candle Resampling:**
   - Updated the `resample` method to include `label='right'` and `closed='right'` to ensure that the resampled candles are labeled and closed at the right boundary of each timeframe.
   - Added logic to align timestamps on the resampled DataFrame to the exact boundary of the timeframe using the `floor` method. This ensures that the resampled candles' timestamps are consistent with the timeframe boundaries.

2. **GitHub File Path Handling:**
   - Modified the `update_github_file` function to ensure the file path is relative to the repository's root and resides in the correct `data` directory.
   - Fixed the logic for creating and updating files in the repository by ensuring that the correct relative path is used, especially when updating or creating files in the `data` directory.

These changes enhance the accuracy of the resampled candle data and improve the reliability of the file update process in the GitHub repository.