### PR TITLE
Add Pretty Printing to JSON Output in `save_and_update_github` Function

### DIFF
--- a/tickr/fetch_candles.py
+++ b/tickr/fetch_candles.py
@@ -89,12 +89,13 @@ def save_and_update_github(file_path, resampled, symbol, timeframe, year, month)
     combined_df['timestamp'] = combined_df['timestamp'].apply(lambda x: int(x.timestamp() * 1000))
     combined_candles = combined_df.to_dict('records')
 
-    # Save updated data back to the file
+    # Save updated data back to the file with pretty printing
     with open(file_path, 'w') as f:
-        json.dump(combined_candles, f)
+        json.dump(combined_candles, f, indent=4)  # Added indent=4 for pretty printing
 
     repo = get_github_repo()
     update_github_file(repo, file_path, symbol, timeframe, year, month)
+
 
 def update_github_file(repo, file_path, symbol, timeframe, year, month):
     with open(file_path, 'r') as f:


### PR DESCRIPTION
This PR enhances the `save_and_update_github` function in `fetch_candles.py` by adding pretty printing to the JSON output. Specifically:

- Added `indent=4` to the `json.dump` call to format the JSON data with indentation for better readability.
- This change does not affect the functionality but improves the clarity of the JSON files stored in the repository.

This update is intended to make the JSON output more human-readable when viewing the files directly on GitHub or in local storage.