### PR TITLE
Enhance Candle Fetching Script: Avoid Current Candle and Push to GitHub Only if Changes Detected

### DIFF
--- a/tickr/fetch_candles.py
+++ b/tickr/fetch_candles.py
@@ -34,24 +34,57 @@ def get_github_repo(repo_name):
 def fetch_and_save_candles(exchange, symbol, timeframe, data_dir, repo_name):
     print(f"Fetching {timeframe} candles for {symbol} on {exchange.id}...")
 
+    # Prepare directories for saving data
+    shard_dir = os.path.join(data_dir, exchange.id, symbol.replace('/', '-'), timeframe)
+    if not os.path.exists(shard_dir):
+        os.makedirs(shard_dir)
+
+    # Determine the last recorded candle's timestamp
+    last_timestamp = None
+    latest_file = None
+    if os.path.exists(shard_dir):
+        for root, dirs, files in os.walk(shard_dir):
+            for file in sorted(files, reverse=True):
+                if file.endswith('.json'):
+                    latest_file = os.path.join(root, file)
+                    with open(latest_file, 'r') as f:
+                        existing_candles = json.load(f)
+                    if existing_candles:
+                        last_timestamp = existing_candles[-1]['timestamp']
+                    break
+            if last_timestamp:
+                break
+
+    if last_timestamp:
+        print(f"Last recorded candle timestamp: {last_timestamp} (ms)")
+
     try:
         # Fetch candles from the exchange
-        since = exchange.parse8601('2021-01-01T00:00:00Z')
+        since = last_timestamp + 1 if last_timestamp else exchange.parse8601('2021-01-01T00:00:00Z')
         candles = exchange.fetch_ohlcv(symbol, timeframe, since=since)
 
-        df = pd.DataFrame(candles, columns=['timestamp', 'open', 'high', 'low', 'close', 'volume'])
-        df['timestamp'] = pd.to_datetime(df['timestamp'], unit='ms')
-        df.set_index('timestamp', inplace=True)
+        if candles:
+            # Remove the current candle (if any)
+            current_time = int(datetime.now().timestamp() * 1000)
+            candles = [candle for candle in candles if candle[0] < current_time]
 
-        for name, group in df.groupby([df.index.year, df.index.month]):
-            year, month = name
-            shard_filename = f"{exchange.id}_{symbol.replace('/', '-')}_{timeframe}_{year}-{month:02d}.json"
-            file_path = os.path.join(data_dir, exchange.id, symbol.replace('/', '-'), timeframe, str(year), f"{month:02d}", shard_filename)
+            if not candles:
+                print("No new candles to record.")
+                return
 
-            if not os.path.exists(os.path.dirname(file_path)):
-                os.makedirs(os.path.dirname(file_path))
-            
-            save_and_update_github(file_path, group, symbol, timeframe, year, month, repo_name)
+            df = pd.DataFrame(candles, columns=['timestamp', 'open', 'high', 'low', 'close', 'volume'])
+            df['timestamp'] = pd.to_datetime(df['timestamp'], unit='ms')
+            df.set_index('timestamp', inplace=True)
+
+            for name, group in df.groupby([df.index.year, df.index.month]):
+                year, month = name
+                shard_filename = f"{exchange.id}_{symbol.replace('/', '-')}_{timeframe}_{year}-{month:02d}.json"
+                file_path = os.path.join(data_dir, exchange.id, symbol.replace('/', '-'), timeframe, str(year), f"{month:02d}", shard_filename)
+
+                if not os.path.exists(os.path.dirname(file_path)):
+                    os.makedirs(os.path.dirname(file_path))
+                
+                save_and_update_github(file_path, group, symbol, timeframe, year, month, repo_name)
 
     except ccxt.NetworkError as e:
         print(f"Network error: {e}")
@@ -61,29 +94,46 @@ def fetch_and_save_candles(exchange, symbol, timeframe, data_dir, repo_name):
         print(f"An unexpected error occurred: {e}")
 
 def save_and_update_github(file_path, group, symbol, timeframe, year, month, repo_name):
-    # Load existing data if file exists
-    if os.path.exists(file_path):
-        with open(file_path, 'r') as f:
-            existing_candles = json.load(f)
-        existing_df = pd.DataFrame(existing_candles, columns=['timestamp', 'open', 'high', 'low', 'close', 'volume'])
-        existing_df['timestamp'] = pd.to_datetime(existing_df['timestamp'], unit='ms')
-        existing_df.set_index('timestamp', inplace=True)
-        combined_df = pd.concat([existing_df, group])
-        combined_df = combined_df[~combined_df.index.duplicated(keep='last')]
-    else:
-        combined_df = group
+    combined_df = group
 
     # Convert the DataFrame index (Timestamp) to milliseconds since epoch
     combined_df.reset_index(inplace=True)
     combined_df['timestamp'] = combined_df['timestamp'].apply(lambda x: int(x.timestamp() * 1000))
     combined_candles = combined_df.to_dict('records')
 
-    # Save updated data back to the file with pretty printing
-    with open(file_path, 'w') as f:
+    # Save the data to a temporary location first
+    temp_file_path = f"{file_path}.temp"
+    with open(temp_file_path, 'w') as f:
         json.dump(combined_candles, f, indent=4)  # Added indent=4 for pretty printing
 
     repo = get_github_repo(repo_name)
-    update_github_file(repo, file_path, symbol, timeframe, year, month)
+
+    # Check if the file exists on GitHub and compare the content
+    try:
+        contents = repo.get_contents(file_path)
+        existing_content = contents.decoded_content.decode('utf-8')
+
+        with open(temp_file_path, 'r') as f:
+            new_content = f.read()
+
+        if existing_content == new_content:
+            print(f"No changes detected for {file_path}. Skipping update.")
+            os.remove(temp_file_path)
+            return
+        else:
+            repo.update_file(contents.path, f"Update {symbol} {timeframe} candles for {year}-{month:02d}", new_content, contents.sha)
+            print(f"Updated {file_path} on GitHub.")
+    except GithubException as e:
+        if e.status == 404:
+            with open(temp_file_path, 'r') as f:
+                new_content = f.read()
+            repo.create_file(file_path, f"Add {symbol} {timeframe} candles for {year}-{month:02d}", new_content)
+            print(f"Created {file_path} on GitHub.")
+        else:
+            raise
+
+    # Save the new content locally
+    os.rename(temp_file_path, file_path)
 
 def update_github_file(repo, file_path, symbol, timeframe, year, month):
     with open(file_path, 'r') as f:


### PR DESCRIPTION
This PR introduces improvements to the `fetch_candles.py` script, focusing on optimizing the candle fetching process and ensuring efficient updates to the GitHub repository.

#### Key Changes:
1. **Avoid Recording Current Candle**:
   - Modified the script to exclude the current, incomplete candle from being recorded. Only fully completed candles are fetched and saved, ensuring accuracy in the recorded data.

2. **Fetch Candles After Last Recorded Candle**:
   - Implemented logic to fetch only those candles that have occurred after the last recorded candle. This prevents duplication and reduces unnecessary data fetching.

3. **Push to GitHub Only if Changes Detected**:
   - Added a content comparison step before pushing updates to the GitHub repository. The script now checks if there are any differences between the existing file on GitHub and the newly generated content. If no changes are detected, the update is skipped, minimizing redundant commits and API requests.

4. **File Handling Improvements**:
   - Introduced temporary file saving to ensure that only relevant and new data is written to both local storage and GitHub. The final file is renamed only after all checks are passed, adding an additional layer of reliability to the process.

These enhancements improve the efficiency and accuracy of the candle data management process, ensuring that the repository remains clean and up-to-date without unnecessary data or commits.
