### PR TITLE
Add Validation for Timeframe Before Fetching Candles (MINOR)

### DIFF
--- a/tests/test_fetch_candles.py
+++ b/tests/test_fetch_candles.py
@@ -11,6 +11,7 @@ class TestFetchCandles(unittest.TestCase):
         # Setup mock return values
         mock_exchange = mock_exchange_class.return_value
         mock_exchange.id = 'kraken'  # Explicitly set the exchange ID
+        mock_exchange.timeframes = {'1m': '1 minute', '1h': '1 hour'}  # Mock supported timeframes
         mock_exchange.fetch_ohlcv.return_value = [
             [1609459200000, 29000, 29500, 28800, 29400, 1000],  # Mocked candle data
             [1609545600000, 29400, 29700, 29200, 29500, 1200]
@@ -19,15 +20,30 @@ class TestFetchCandles(unittest.TestCase):
         mock_repo = MagicMock()
         mock_get_repo.return_value = mock_repo
 
-        # Call the function with required parameters
+        # Test with a supported timeframe
         fetch_and_save_candles(mock_exchange, 'BTC/USD', '1m', 'data', 'syncsoftco/tickr')
 
-        # Assertions
+        # Assertions for supported timeframe
         mock_exchange.fetch_ohlcv.assert_called_once_with('BTC/USD', '1m', since=mock_exchange.parse8601('2021-01-01T00:00:00Z'))
         
         # Check that save_and_update_github was called
         expected_file_path = 'data/kraken/BTC-USD/1m/2021/01/kraken_BTC-USD_1m_2021-01.json'
         mock_save_and_update.assert_called_once_with(expected_file_path, unittest.mock.ANY, 'BTC/USD', '1m', 2021, 1, 'syncsoftco/tickr')
+
+    def test_fetch_candles_unsupported_timeframe(self):
+        # Setup a mock exchange with limited timeframes
+        mock_exchange = MagicMock()
+        mock_exchange.id = 'kraken'
+        mock_exchange.timeframes = {'1m': '1 minute', '1h': '1 hour'}
+
+        # Attempt to call with an unsupported timeframe
+        with self.assertRaises(ValueError) as context:
+            fetch_and_save_candles(mock_exchange, 'BTC/USD', '6h', 'data', 'syncsoftco/tickr')
+
+        # Verify the error message
+        self.assertIn("Unsupported timeframe", str(context.exception))
+        self.assertIn("6h", str(context.exception))
+        self.assertIn("Supported timeframes", str(context.exception))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tickr/fetch_candles.py
+++ b/tickr/fetch_candles.py
@@ -32,8 +32,11 @@ def get_github_repo(repo_name):
     return repo
 
 def fetch_and_save_candles(exchange, symbol, timeframe, data_dir, repo_name):
+    if timeframe not in exchange.timeframes:
+        raise ValueError("Unsupported timeframe: %s Supported timeframes: %s", timeframe, exchange.timeframes)
+    
     print(f"Fetching {timeframe} candles for {symbol} on {exchange.id}...")
-
+     
     # Prepare directories for saving data
     shard_dir = os.path.join(data_dir, exchange.id, symbol.replace('/', '-'), timeframe)
     if not os.path.exists(shard_dir):


### PR DESCRIPTION
This PR adds a validation step in the `fetch_and_save_candles` function to check if the specified `timeframe` is supported by the exchange before attempting to fetch candle data. 

- **Validation Added**: The script now raises a `ValueError` if the provided `timeframe` is not supported by the exchange. The error message includes both the unsupported `timeframe` and the list of `exchange.timeframes` that are supported.
- **Code Adjustment**: The validation occurs immediately after the function parameters are received, ensuring that unsupported timeframes are caught early.

This update ensures that only valid and supported timeframes are used, reducing the likelihood of runtime errors when fetching candle data.