### PR TITLE
Remove debugging print statements from `test_tickr_client.py`

### DIFF
--- a/tests/test_tickr_client.py
+++ b/tests/test_tickr_client.py
@@ -40,8 +40,6 @@ class TestTickrClient(unittest.TestCase):
         start_date = datetime(2021, 1, 1)  # Adjust this as needed to match mock data
         candles = self.client.get_candles(symbol, timeframe, start_date=start_date, end_date=end_date)
         
-        print(f"Mocked candles: {candles}")
-
         self.assertIsNotNone(candles, "Candles should not be None")
         self.assertTrue(len(candles) > 0, "Candles should contain data")
 
@@ -56,8 +54,6 @@ class TestTickrClient(unittest.TestCase):
 
         candles = self.client.get_candles(symbol, timeframe, start_date=start_date, end_date=end_date)
         
-        print(f"Custom range candles: {candles}")
-
         self.assertIsNotNone(candles, "Candles should not be None")
         self.assertTrue(len(candles) > 0, "Candles should contain data")
         self.assertTrue(all(start_date <= datetime.fromtimestamp(candle[0] / 1000) <= end_date for candle in candles), 


### PR DESCRIPTION
This PR cleans up the `test_tickr_client.py` file by removing two `print` statements that were likely used for debugging purposes. These print statements outputted the mocked candle data to the console, which is not necessary for the tests themselves. Removing them improves the readability of the test output and prevents unnecessary clutter in the console during test execution. 

No functional changes are made to the tests or the `TickrClient` class. 
