### PR TITLE
Update Candles Workflow: Adjust Timeframes for Data Retrieval

### DIFF
--- a/.github/workflows/update_candles.yaml
+++ b/.github/workflows/update_candles.yaml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         exchange: ["kraken"]
         symbol: ["BTC/USD", "ETH/USD"]
-        timeframe: ['1m', '5m', '15m', '1h', '6h', '12h', '1d', '1w']
+        timeframe: ['1m', '5m', '15m', '30m', '1h', '4h', '1d', '1w']
           
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
This pull request modifies the `update_candles.yaml` workflow to adjust the timeframes used for retrieving candle data from the Kraken exchange. 

**Key Changes:**

* **Removed Timeframes:** 6h, 12h
* **Added Timeframe:** 30m, 4h

These changes aim to optimize the data collection process and align the retrieved timeframes with common analysis needs.

Please review and merge if these changes are in line with project requirements.