### PR TITLE
Add Coinbase Advanced to Candle Update Workflow

### DIFF
--- a/.github/workflows/update_candles.yaml
+++ b/.github/workflows/update_candles.yaml
@@ -9,7 +9,7 @@ jobs:
   update-candles:
     strategy:
       matrix:
-        exchange: ["kraken"]
+        exchange: ["coinbaseadvanced", "kraken"]
         symbol: ["BTC/USD", "ETH/USD"]
         timeframe: ['1m', '5m', '15m', '30m', '1h', '4h', '1d', '1w']
           


### PR DESCRIPTION
This PR extends the `update_candles` workflow to include data from Coinbase Advanced in addition to Kraken. The same set of symbols (BTC/USD, ETH/USD) and timeframes will be fetched from both exchanges.