### PR TITLE
Increase Retry Attempts for `save_and_update_github` Function

### DIFF
--- a/tickr/fetch_candles.py
+++ b/tickr/fetch_candles.py
@@ -95,7 +95,7 @@ def extract_timestamp(x):
 
     return x.timestamp()
 
-@backoff.on_exception(backoff.expo, GithubException, max_tries=3, giveup=lambda e: e.status != 409)
+@backoff.on_exception(backoff.expo, GithubException, max_tries=7, giveup=lambda e: e.status != 409)
 def save_and_update_github(file_path, group, symbol, timeframe, year, month, repo_name):
     combined_df = group
 


### PR DESCRIPTION
This update increases the maximum number of retry attempts from 3 to 7 in the `save_and_update_github` function when encountering a `GithubException`. This adjustment aims to improve the resilience of the function, ensuring that data updates to GitHub are more robust, particularly in cases of transient errors or intermittent connectivity issues. The backoff mechanism remains in place, with the same exponential strategy applied.