### PR TITLE
Improve Retry Logic in GitHub Actions Workflow for Updating Candles

### DIFF
--- a/.github/workflows/update_candles.yaml
+++ b/.github/workflows/update_candles.yaml
@@ -12,7 +12,7 @@ jobs:
         exchange: ["coinbaseadvanced", "kraken"]
         symbol: ["BTC/USD", "ETH/USD"]
         timeframe: ['1m', '5m', '15m', '30m', '1h', '1d']
-          
+
     runs-on: ubuntu-latest
 
     steps:
@@ -30,11 +30,14 @@ jobs:
         pip install .
 
     - name: Fetch and update candles
+      uses: nick-fields/retry@v2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Use GitHub token for authentication
-      run: |
-        python -m tickr.fetch_candles \
-          --exchange=${{ matrix.exchange }} \
-          --symbol=${{ matrix.symbol }} \
-          --timeframe=${{ matrix.timeframe }}
-
+      with:
+        timeout_minutes: 10
+        max_attempts: 3
+        command: |
+          python -m tickr.fetch_candles \
+            --exchange=${{ matrix.exchange }} \
+            --symbol=${{ matrix.symbol }} \
+            --timeframe=${{ matrix.timeframe }}


### PR DESCRIPTION
This update refines the `update_candles.yaml` GitHub Actions workflow by integrating the `nick-fields/retry` action for more robust execution of the `fetch_candles.py` script. It introduces a retry mechanism with a specified timeout and a maximum number of attempts, enhancing the workflow's reliability in case of transient errors or network issues. The configuration now allows for up to 3 retries, ensuring that the candle-fetching process is more resilient.