### PR TITLE
Enhance Candle Fetcher Timestamp Handling and Add Exchange Validation

### DIFF
--- a/tests/test_fetch_candles.py
+++ b/tests/test_fetch_candles.py
@@ -8,7 +8,7 @@ import json
 
 class TestFetchCandles(unittest.TestCase):
 
-    @patch('fetch_candles.ccxt')
+    @patch('tickr.fetch_candles.ccxt')
     def test_initialize_exchange_success(self, mock_ccxt):
         mock_exchange_class = MagicMock()
         mock_exchange = MagicMock()
@@ -23,7 +23,7 @@ class TestFetchCandles(unittest.TestCase):
         with self.assertRaises(ValueError):
             initialize_exchange('nonexistent_exchange')
 
-    @patch('fetch_candles.ccxt.Exchange')
+    @patch('tickr.fetch_candles.ccxt.Exchange')
     def test_candle_fetcher_fetch_and_save_candles(self, mock_exchange_class):
         # Set up mock exchange
         mock_exchange = MagicMock()


### PR DESCRIPTION
This pull request includes updates to the `CandleFetcher` class and related tests to improve the handling of timestamps and better validation of exchange capabilities.

#### Key Changes:
1. **Timestamp Handling Improvements:**
   - Updated the default `get_since_timestamp` logic to start fetching candles from one year ago if no previous data is available. This is more realistic than starting from `0`.
   - Adjusted date formatting to ensure proper timezone handling using `datetime.timezone.utc` throughout the code for better consistency with UTC-based timestamps.

2. **Exchange Validation:**
   - Added a check in `initialize_exchange` to ensure that the exchange supports fetching OHLCV data. If not, an error is raised to prevent further execution.

3. **Test Adjustments:**
   - Modified the unit tests for `get_since_timestamp`:
     - For cases with no existing files, the test now asserts that candles are fetched starting from one year ago, allowing for a small timing difference (`delta=1000`) to account for system time variations.
     - For empty files, the test now uses `datetime.timezone.utc` to ensure proper timestamp calculations.
   - Additional mock setups for `load_markets` in tests to better simulate real exchange behavior.

These changes ensure that the `CandleFetcher` is more robust, correctly handling missing data and invalid exchange configurations, while maintaining accurate time tracking for candle data.