### PR TITLE
Update file extension from `.json` to `.jsonl` for candle data storage

### DIFF
--- a/tests/test_fetch_candles.py
+++ b/tests/test_fetch_candles.py
@@ -50,7 +50,7 @@ class TestFetchCandles(unittest.TestCase):
             self.assertTrue(any('2021-01-02' in file for file in files))
 
             # Verify content of one of the files
-            file_path = os.path.join(data_directory, 'BTC_USDT_2021-01-01.json')
+            file_path = os.path.join(data_directory, 'BTC_USDT_2021-01-01.jsonl')
             with open(file_path, 'r') as f:
                 lines = f.readlines()
                 self.assertEqual(len(lines), 2)  # Two candles for Jan 1, 2021
@@ -76,7 +76,7 @@ class TestFetchCandles(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as data_directory:
             # Create a mock file for Jan 1, 2021 with existing data
-            file_name = os.path.join(data_directory, 'BTC_USDT_2021-01-01.json')
+            file_name = os.path.join(data_directory, 'BTC_USDT_2021-01-01.jsonl')
             existing_candle = [1609459200000, 29000, 29500, 28900, 29400, 100]
             with open(file_name, 'w') as f:
                 f.write(json.dumps(existing_candle) + '\n')
@@ -91,7 +91,7 @@ class TestFetchCandles(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as data_directory:
             # Create an empty file for Jan 1, 2021
-            file_name = os.path.join(data_directory, 'BTC_USDT_2021-01-01.json')
+            file_name = os.path.join(data_directory, 'BTC_USDT_2021-01-01.jsonl')
             with open(file_name, 'w') as f:
                 pass  # Create an empty file
 
@@ -106,10 +106,10 @@ class TestFetchCandles(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as data_directory:
             # Create files for different symbols
-            with open(os.path.join(data_directory, 'BTC_USDT_2021-01-01.json'), 'w') as f:
+            with open(os.path.join(data_directory, 'BTC_USDT_2021-01-01.jsonl'), 'w') as f:
                 existing_candle = [1609459200000, 29000, 29500, 28900, 29400, 100]
                 f.write(json.dumps(existing_candle) + '\n')
-            with open(os.path.join(data_directory, 'ETH_USDT_2021-01-02.json'), 'w') as f:
+            with open(os.path.join(data_directory, 'ETH_USDT_2021-01-02.jsonl'), 'w') as f:
                 existing_candle_eth = [1609545600000, 730, 750, 720, 740, 200]
                 f.write(json.dumps(existing_candle_eth) + '\n')
 

--- a/tickr/fetch_candles.py
+++ b/tickr/fetch_candles.py
@@ -90,7 +90,7 @@ class CandleFetcher:
                 return last_candle[0] + 1  # Continue from the last timestamp
 
             # Empty file, use the date from filename
-            latest_date_str = latest_file[len(prefix):-5]  # Remove prefix and '.json'
+            latest_date_str = latest_file[len(prefix):-6]  # Remove prefix and '.jsonl'
             latest_date = datetime.datetime.strptime(latest_date_str, '%Y-%m-%d').replace(tzinfo=datetime.timezone.utc)
             return int(latest_date.timestamp() * 1000)
 
@@ -104,7 +104,7 @@ class CandleFetcher:
             daily_candles[date_str].append(candle)
 
         for date_str, candles in daily_candles.items():
-            file_name = f"{self.symbol.replace('/', '_')}_{date_str}.json"
+            file_name = f"{self.symbol.replace('/', '_')}_{date_str}.jsonl"
             file_path = os.path.join(self.data_directory, file_name)
             with open(file_path, 'a') as f:
                 for candle in candles:


### PR DESCRIPTION
This PR updates the file extension used for storing candle data from `.json` to `.jsonl` to better handle line-delimited JSON data. Adjustments are made in both the test cases and the `fetch_candles.py` script to reflect this change, ensuring compatibility with the new file format.